### PR TITLE
Tarball rendered docs before artifact upload

### DIFF
--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -48,8 +48,15 @@ jobs:
             exit 1
           fi
 
+      # Tar the rendered site so files whose names contain characters that
+      # actions/upload-artifact@v4 rejects (e.g. "*" used as a wildcard
+      # placeholder in simulation output filenames) are preserved inside the
+      # archive. See #4.
+      - name: Package rendered docs as tarball
+        run: tar -czf rendered-site.tar.gz -C docs .
+
       - name: Upload static files as artifact
         uses: actions/upload-artifact@v4
         with:
           name: rendered-site
-          path: docs/
+          path: rendered-site.tar.gz


### PR DESCRIPTION
## Summary

`actions/upload-artifact@v4` rejects filenames containing characters that are reserved on some file systems (NTFS), including \`*\`. The SIMWE simulation generates output files whose names use \`*\` as a wildcard placeholder (e.g. \`depth_sum_1_*_1_stats_max_raster.gif\`), so the Quarto PR check fails when uploading \`docs/\` as an artifact.

This PR tars the rendered site first; the archive preserves arbitrary filenames, mirroring what \`actions/upload-pages-artifact\` (used by \`publish.yml\`) already does internally.

Closes #4.

## Changes

Single change to `.github/workflows/pr-check.yml`:

```diff
+      - name: Package rendered docs as tarball
+        run: tar -czf rendered-site.tar.gz -C docs .
+
       - name: Upload static files as artifact
         uses: actions/upload-artifact@v4
         with:
           name: rendered-site
-          path: docs/
+          path: rendered-site.tar.gz
```

## Test plan

- [x] YAML parses (\`python3 -c \"import yaml; yaml.safe_load(open(...))\"\`).
- [x] Local tar round-trip test: created \`/tmp/.../depth_sum_1_*_1_stats_max_raster.gif\`, archived via \`tar -czf\`, extracted — filename preserved with the literal \`*\` intact.
- [x] **End-to-end CI verification:** ran the fixed workflow on a fork with the actual Quarto render pipeline. All steps succeeded including \`Package rendered docs as tarball\` (new) and \`Upload static files as artifact\` (previously failing). Run: https://github.com/gkneighb/NRCS_SIMWE/actions/runs/25980543851

## Downstream consideration

Anyone downloading the \`rendered-site\` artifact will now need to extract the tarball rather than browse files directly. For a CI artifact this seems fine — the artifact's purpose is verification, not direct browsing — but happy to adjust if you'd prefer an exclusion-based fix or to keep \`docs/\` browsable and only tar the \`notebooks/output/\` subtree.